### PR TITLE
feat: make API base URL configurable

### DIFF
--- a/ser-app/DATA_FETCHING_GUIDE.md
+++ b/ser-app/DATA_FETCHING_GUIDE.md
@@ -79,8 +79,8 @@ npm run dev
 ## 🚀 **URLs After Starting**
 
 - **Frontend:** http://localhost:5173
-- **Backend API:** http://localhost:5000
-- **Test API:** http://localhost:5000/api/auth/me
+- **Backend API:** value of `VITE_API_URL` (defaults to http://localhost:5000)
+- **Test API:** `${VITE_API_URL}/api/auth/me`
 
 ## Overview
 Your website now has a complete data fetching system that automatically connects to your Flask backend and manages all the data for your application.
@@ -88,7 +88,7 @@ Your website now has a complete data fetching system that automatically connects
 ## What's Changed
 
 ### 1. API Service (`src/services/api.js`)
-- Now connects to your actual backend at `http://localhost:5000`
+- Now connects to your backend using the `VITE_API_URL` environment variable (falls back to same origin)
 - Handles all authentication, chat, and user data
 - Includes proper error handling and session management
 

--- a/ser-app/src/services/api.js
+++ b/ser-app/src/services/api.js
@@ -2,7 +2,9 @@
 
 class ApiService {
   constructor() {
-    this.baseURL = 'http://localhost:5000'; // Your Flask backend URL
+    // Allow configuring the backend URL via environment variable
+    const envBase = import.meta?.env?.VITE_API_URL || '';
+    this.baseURL = envBase.replace(/\/$/, '');
   }
 
   async request(endpoint, options = {}) {

--- a/ser-app/test/dataFetchingTest.js
+++ b/ser-app/test/dataFetchingTest.js
@@ -3,13 +3,15 @@
 
 import apiService from '../src/services/api.js';
 
+const API_BASE_URL = (import.meta?.env?.VITE_API_URL || '').replace(/\/$/, '');
+
 // Test function to check if backend is responding
 export const testBackendConnection = async () => {
   try {
     console.log('Testing backend connection...');
     
     // Test basic connection
-    const response = await fetch('http://localhost:5000/api/auth/me', {
+    const response = await fetch(`${API_BASE_URL}/api/auth/me`, {
       credentials: 'include'
     });
     


### PR DESCRIPTION
## Summary
- allow configuring backend URL through `VITE_API_URL`
- update data fetching tests and docs to use configurable API URL

## Testing
- `python -m pytest`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68911ae1cff883239376c92a96038982